### PR TITLE
chore: enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "actions/*"
+      third-party-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "actions/*"


### PR DESCRIPTION
## What type of PR is this?
- [x] chore

## What this PR does
Enables Dependabot for the `github-actions` ecosystem. The repository currently has one workflow (`pages-deploy.yml`) using third-party actions; e.g. `actions/upload-pages-artifact` is still at `@v3` while `@v5` is current.

Weekly schedule, grouped updates (first-party `actions/*` vs. third-party), mirrors the configuration already in use in `project-administration`.

## Does this PR introduce a breaking change?
- [x] No

## Notes for reviewers
- Config scope limited to `github-actions`; no other package ecosystems are present in the repo.
- Labels `dependencies` and `github-actions` will be auto-created by Dependabot on first PR.

## Changelog input
N/A — tooling/automation only.

## Additional documentation
N/A